### PR TITLE
fix: uncaught error in illustsPageNext

### DIFF
--- a/src/views/Rank.vue
+++ b/src/views/Rank.vue
@@ -207,7 +207,9 @@ export default {
           $state.loaded();
         })
         .catch((error) => {
-          this.error(error.response.data.message);
+          if (error?.response?.data) {
+            this.error(error?.response?.data?.message);
+          }
           $state.error();
         });
     },


### PR DESCRIPTION
When a request has already aborted by user, the `error.response.data.message` will always throw an error, it will lead to a crash to infinite loader.